### PR TITLE
Adjust UIImage parameter for using SF Symbols

### DIFF
--- a/Example/ContentView.swift
+++ b/Example/ContentView.swift
@@ -54,7 +54,8 @@ struct ConfettiCelebrationView: View {
             .text("💪"),
             .shape(.circle),
             .shape(.triangle),
-            .image(UIImage(named: "star")!)
+            // if using SF symbols, UIImage takes systemName to build
+            .image(UIImage(systemName: "star")!)
         ]).transition(.slowFadeOut)
 
         return ZStack {


### PR DESCRIPTION
Xcode ver 12.0.1
macOS 10.15.6

This change builds the UIImage in view instead causing black screen lapsed for timeLimit