### PR TITLE
Prevent animation to run more than once

### DIFF
--- a/Sources/ConfettiView/ConfettiView.swift
+++ b/Sources/ConfettiView/ConfettiView.swift
@@ -43,8 +43,14 @@ public enum Confetti {
 
 /// The UIView Confetti Emitter
 public final class UIConfettiView: UIView {
-
+    
+    private var once: Bool = false
+    
     func emit(with contents: [Confetti]) {
+        if once {
+            return
+        }
+        
         let layer = Layer()
         layer.configure(with: contents)
         layer.frame = self.bounds
@@ -52,6 +58,7 @@ public final class UIConfettiView: UIView {
         layer.position = CGPoint(x: UIScreen.main.bounds.width / 2 , y: -UIScreen.main.bounds.height)
         layer.emitterShape = .line
         self.layer.addSublayer(layer)
+        once.toggle()
     }
 
 }


### PR DESCRIPTION
Every time you dismiss a child view, ConfettiView will emit to UIConfettiView, causing it to create more and more layers, filling the screen with confetti.
A once condition was added to the emit function in UIConfettiView to prevent this issue.